### PR TITLE
Make get_vmr non-allocating

### DIFF
--- a/src/rrtmgp/mo_gas_concentrations.jl
+++ b/src/rrtmgp/mo_gas_concentrations.jl
@@ -23,8 +23,7 @@ using DocStringExtensions
 using ..fortran_intrinsics
 using ..Utilities
 export ty_gas_concs
-export get_vmr
-export set_vmr!
+export set_vmr!, get_vmr!
 export GasConcSize
 
 const GAS_NOT_IN_LIST = -1
@@ -58,7 +57,7 @@ struct ty_gas_concs{FT}
 end
 
 function ty_gas_concs(::Type{FT}, gas_names, ncol, nlay, gsc::GasConcSize) where FT
-  concs = [conc_field(Array{FT}(undef, gsc.s...)) for i in 1:gsc.nconcs]
+  concs = [conc_field(zeros(FT, gsc.s...)) for i in 1:gsc.nconcs]
   return ty_gas_concs{FT}(gas_names, concs, gsc.s..., gsc)
 end
 
@@ -89,52 +88,26 @@ function set_vmr!(this::ty_gas_concs, gas::String, w::Array{FT, 2}) where FT
   this.gas_name[igas] = gas
 end
 
-# Return volume mixing ratio as 1D or 2D array
-# 1D array ( lay depdendence only)
-function get_vmr(this::ty_gas_concs{FT}, gas::String) where FT
-  # real(FT), dimension(:),   intent(out) :: array
+"""
+    get_vmr!(array::AbstractArray{FT,2}, this::ty_gas_concs{FT}, gas::String) where FT
 
+Volume mixing ratio ( nlay dependence only)
+"""
+function get_vmr!(array::AbstractArray{FT,2}, this::ty_gas_concs{FT}, gas::String) where FT
   igas = loc_in_array(gas, this.gas_name)
   @assert igas ≠ GAS_NOT_IN_LIST
+  @assert !(this.ncol ≠ nothing && this.ncol ≠ size(array,1))
+  @assert !(this.nlay ≠ nothing && this.nlay ≠ size(array,2))
   conc = this.concs[igas].conc
 
-  # this.ncol == nothing && (this.ncol = 1)
-
-  array = Array{FT}(undef, this.ncol, this.nlay)
-
   if size(conc, 1) > 1     # Concentration stored as 2D
-    array .= conc[:,:]
+    array .= conc
   elseif size(conc, 2) > 1 # Concentration stored as 1D
     array .= reshape(conc[1,:], this.ncol, this.nlay)
   else                     # Concentration stored as scalar
-    fill!(array, conc[1,1])
+    array .= conc[1,1]
   end
-
-  @assert !(this.ncol ≠ nothing && this.ncol ≠ size(array,1))
-  @assert !(this.nlay ≠ nothing && this.nlay ≠ size(array,2))
-
-  return array
-end
-
-# 2D array (col, lay)
-function get_vmr(this::ty_gas_concs, gas::String, array::Array{FT,2}) where FT
-  # real(FT), dimension(:,:), intent(out) :: array
-
-  igas = loc_in_array(gas, this.gas_name)
-  @assert igas ≠ GAS_NOT_IN_LIST
-
-  # Is the requested array the correct size?
-  @assert !(this.ncol ≠ nothing && this.ncol ≠ size(array,1))
-  @assert !(this.nlay ≠ nothing && this.nlay ≠ size(array,2))
-
-  if size(this.concs[igas].conc, 1) > 1      # Concentration stored as 2D
-    array = this.concs[igas].conc[:,:]
-  elseif size(this.concs(igas).conc, 2) > 1 # Concentration stored as 1D
-    array = spread(this.concs(igas).conc(1,:), dim=1, ncopies=max(this.ncol, size(array,1)))
-  else                                                   # Concentration stored as scalar
-    array = this.concs[igas].conc[1,1]
-  end
-  return array
+  return nothing
 end
 
 end # module

--- a/src/rrtmgp/mo_gas_optics_rrtmgp.jl
+++ b/src/rrtmgp/mo_gas_optics_rrtmgp.jl
@@ -318,9 +318,9 @@ function compute_gas_taus!(jtemp, jpress, jeta, tropo, fmajor, this::ty_gas_opti
   check_key_species_present(this, gas_desc)
 
   # Check input data sizes and values
-  check_extent(play, (ncol, nlay  ),   "play")
+  check_extent(play, (ncol, nlay  ), "play")
   check_extent(plev, (ncol, nlay+1), "plev")
-  check_extent(tlay, (ncol, nlay  ),   "tlay")
+  check_extent(tlay, (ncol, nlay  ), "tlay")
   check_range(play, this.press_ref_min,this.press_ref_max, "play")
   check_range(plev, this.press_ref_min, this.press_ref_max, "plev")
   check_range(tlay, this.temp_ref_min,  this.temp_ref_max,  "tlay")
@@ -343,8 +343,8 @@ function compute_gas_taus!(jtemp, jpress, jeta, tropo, fmajor, this::ty_gas_opti
   # Fill out the array of volume mixing ratios
   for igas in 1:ngas
     # Get vmr if  gas is provided in ty_gas_concs
-    if lowercase(this.gas_names[igas]) in gas_desc.gas_name
-      vmr[:,:,igas] .= get_vmr(gas_desc, this.gas_names[igas])
+    if this.gas_names[igas] in gas_desc.gas_name
+      get_vmr!(@view(vmr[:,:,igas]), gas_desc, this.gas_names[igas])
     end
   end
 

--- a/test/allsky.jl
+++ b/test/allsky.jl
@@ -23,19 +23,14 @@ using RRTMGP.mo_load_cloud_coefficients
 include("mo_cloud_sampling.jl")
 include("mo_test_files_io.jl")
 
-function vmr_2d_to_1d!(gas_concs, gas_concs_garand, name)
-  # use mo_gas_concentrations, only: ty_gas_concs
-
-  # type(ty_gas_concs), intent(in)    :: gas_concs_garand
-  # type(ty_gas_concs), intent(inout) :: gas_concs
-  # character(len=*),   intent(in)    :: name
-  # integer,            intent(in)    :: sz1, sz2
-
-  # real(wp) :: tmp(sz1, sz2), tmp_col(sz2)
-
-  tmp = get_vmr(gas_concs_garand, name)
+function vmr_2d_to_1d!(gas_concs::ty_gas_concs{FT},
+                       gas_concs_garand::ty_gas_concs{FT},
+                       name::String,
+                       sz1::I,
+                       sz2::I) where {FT<:AbstractFloat,I<:Int}
+  tmp = Array{FT}(undef, sz1, sz2)
+  get_vmr!(tmp, gas_concs_garand, name)
   tmp_col = tmp[1, :]
-
   set_vmr!(gas_concs, name, tmp_col)
 end
 
@@ -140,7 +135,7 @@ function all_sky(ds; use_luts=false, λ_string="", compile_first=false)
   gsc = GasConcSize(ncol, nlay, (ncol, nlay), ngas)
   gas_concs = ty_gas_concs(FT, gas_names, ncol, nlay, gsc)
   for igas = 1:ngas
-    vmr_2d_to_1d!(gas_concs, gas_concs_garand, gas_names[igas])
+    vmr_2d_to_1d!(gas_concs, gas_concs_garand, gas_names[igas], size(p_lay, 1), nlay)
   end
 
   #  If we trusted in Fortran allocate-on-assign we could skip the temp_array here


### PR DESCRIPTION
 - Makes `get_vmr` non-allocating
 - Removes `get_vmr` for rank 1 arrays, since `gas_conc` is only rank 2