### PR TITLE
Make `ty_fluxes_broadband` immutable

### DIFF
--- a/src/rte/mo_fluxes.jl
+++ b/src/rte/mo_fluxes.jl
@@ -31,14 +31,15 @@ Contains up, down, net and direct downward fluxes
 
 $(DocStringExtensions.FIELDS)
 """
-mutable struct ty_fluxes_broadband{FT} <: ty_fluxes{FT}
+struct ty_fluxes_broadband{FT} <: ty_fluxes{FT}
   flux_up#::Array{FT,2}
   flux_dn#::Array{FT,2}
   flux_net#::Array{FT,2}
   flux_dn_dir#::Array{FT,2}
+  ty_fluxes_broadband(FT, s, include_direct::Bool=false) =
+    include_direct ? new{FT}(ntuple(i->Array{FT}(undef, s...),4)...) :
+                     new{FT}(ntuple(i->Array{FT}(undef, s...),3)...,nothing)
 end
-
-ty_fluxes_broadband(FT) = ty_fluxes_broadband{FT}(ntuple(i->nothing, 4)...)
 
 """
     reduce!(this::ty_fluxes_broadband,
@@ -86,16 +87,16 @@ function reduce!(this::ty_fluxes_broadband,
     this.flux_dn .= sum_broadband(ncol, nlev, ngpt, gpt_flux_dn)
   end
   if associated(this.flux_dn_dir)
-    this.flux_dn_dir = sum_broadband(ncol, nlev, ngpt, gpt_flux_dn_dir)
+    this.flux_dn_dir .= sum_broadband(ncol, nlev, ngpt, gpt_flux_dn_dir)
   end
 
   if associated(this.flux_net)
 
     #  Reuse down and up results if possible
     if associated(this.flux_dn) && associated(this.flux_up)
-      this.flux_net = net_broadband(ncol, nlev,      this.flux_dn, this.flux_up)
+      this.flux_net .= net_broadband(ncol, nlev,      this.flux_dn, this.flux_up)
     else
-      this.flux_net = net_broadband(ncol, nlev, ngpt, gpt_flux_dn,  gpt_flux_up)
+      this.flux_net .= net_broadband(ncol, nlev, ngpt, gpt_flux_dn,  gpt_flux_up)
     end
   end
 end
@@ -113,4 +114,4 @@ are_desired(this::ty_fluxes_broadband) =
         associated(this.flux_dn_dir),
         associated(this.flux_net)] )
 
-end
+end #module

--- a/test/allsky.jl
+++ b/test/allsky.jl
@@ -250,7 +250,7 @@ function all_sky(ds; use_luts=false, λ_string="", compile_first=false)
     end
   end
 
-  fluxes = ty_fluxes_broadband(FT)
+  fluxes = ty_fluxes_broadband(FT, size(flux_up), is_sw)
   #
   # Multiple iterations for big problem sizes, and to help identify data movement
   #   For CPUs we can introduce OpenMP threading over loop iterations
@@ -261,8 +261,8 @@ function all_sky(ds; use_luts=false, λ_string="", compile_first=false)
     #
     # Solvers
     #
-    fluxes.flux_up = @view(flux_up[:,:])
-    fluxes.flux_dn = @view(flux_dn[:,:])
+    fluxes.flux_up .= FT(0)
+    fluxes.flux_dn .= FT(0)
     if is_lw
       gas_optics_int!(k_dist, p_lay, p_lev,
                   t_lay, t_sfc,
@@ -278,7 +278,7 @@ function all_sky(ds; use_luts=false, λ_string="", compile_first=false)
               emis_sfc,
               fluxes)
     else
-      fluxes.flux_dn_dir = flux_dir[:,:]
+      fluxes.flux_dn_dir .= flux_dir
 
       gas_optics_ext!(k_dist, p_lay, p_lev,
                   t_lay,
@@ -292,6 +292,8 @@ function all_sky(ds; use_luts=false, λ_string="", compile_first=false)
               sfc_alb_dir, sfc_alb_dif,
               fluxes)
     end
+    flux_up .= fluxes.flux_up
+    flux_dn .= fluxes.flux_dn
   end
 
 

--- a/test/rfmip_clear_sky_lw.jl
+++ b/test/rfmip_clear_sky_lw.jl
@@ -160,11 +160,11 @@ function rfmip_clear_sky_lw(ds, optical_props_constructor; compile_first=false)
   #
   # Loop over blocks
   #
-  fluxes = ty_fluxes_broadband(FT)
+  fluxes = ty_fluxes_broadband(FT, (size(flux_up,1),size(flux_up,2)))
 
   for b = 1:(compile_first ? 1 : nblocks)
-    fup = fluxes.flux_up = @view(flux_up[:,:,b])
-    fdn = fluxes.flux_dn = @view(flux_dn[:,:,b])
+    fluxes.flux_up .= FT(0)
+    fluxes.flux_dn .= FT(0)
 
     for icol = 1:block_size
       for ibnd = 1:nbnd
@@ -183,8 +183,9 @@ function rfmip_clear_sky_lw(ds, optical_props_constructor; compile_first=false)
                 tlev = t_lev[:,:,b])
 
     rte_lw!(optical_props,top_at_1,source,sfc_emis_spec,fluxes,nothing,n_quad_angles)
-    @assert fup === fluxes.flux_up # check if fluxes.flux_up/dn still refers to flux_up[:,:,b]
-    @assert fdn === fluxes.flux_dn
+
+    flux_up[:,:,b] .= fluxes.flux_up
+    flux_dn[:,:,b] .= fluxes.flux_dn
 
   end
 

--- a/test/rfmip_clear_sky_sw.jl
+++ b/test/rfmip_clear_sky_sw.jl
@@ -160,12 +160,12 @@ function rfmip_clear_sky_sw(ds, optical_props_constructor; compile_first=false)
   #
   # Loop over blocks
   #
-  fluxes = ty_fluxes_broadband(FT)
+  fluxes = ty_fluxes_broadband(FT, (size(flux_up,1),size(flux_up,2)), true)
 
   b_tot = (compile_first ? 1 : nblocks)
   @showprogress 1 "Computing..." for b = 1:b_tot
-    fup = fluxes.flux_up = @view(flux_up[:,:,b])
-    fdn = fluxes.flux_dn = @view(flux_dn[:,:,b])
+    fluxes.flux_up .= FT(0)
+    fluxes.flux_dn .= FT(0)
     #
     # Compute the optical properties of the atmosphere and the Planck source functions
     #    from pressures, temperatures, and gas concentrations...
@@ -222,6 +222,8 @@ function rfmip_clear_sky_sw(ds, optical_props_constructor; compile_first=false)
             fluxes)
 
 
+    flux_up[:,:,b] .= fluxes.flux_up
+    flux_dn[:,:,b] .= fluxes.flux_dn
     #
     # Zero out fluxes for which the original solar zenith angle is > 90 degrees.
     #
@@ -232,8 +234,6 @@ function rfmip_clear_sky_sw(ds, optical_props_constructor; compile_first=false)
       end
     end
 
-    @assert fup === fluxes.flux_up
-    @assert fdn === fluxes.flux_dn
   end
 
   # reshaping the flux_up and flux_dn arrays for comparison with Fortran code.


### PR DESCRIPTION
 - Makes `ty_fluxes_broadband` immutable

Note that `fluxes.flux_up/dn` are no longer views of `flux_up/dn`. Instead, `flux_up/dn` is assigned to `fluxes.flux_up/dn` after the solver is called.