### PR TITLE
Move `compress_targz` outside of `src`

### DIFF
--- a/OriginalRRTMGP/TarNewRefernceData.jl
+++ b/OriginalRRTMGP/TarNewRefernceData.jl
@@ -2,6 +2,19 @@ using RRTMGP
 
 # include("AutoRunRRTMGP.jl")
 
+"""
+    compress_targz(file)
+
+Platform-independent file compression
+"""
+function compress_targz(file)
+  if Sys.iswindows()
+    error("Needs to be implemented")
+  else
+    run(`tar -zcvf $file $(readdir())`)
+  end
+end
+
 root_dir = dirname(pwd())
 rte_rrtmgp_folder = "rte-rrtmgp"
 rte_rrtmgp_dir = joinpath(root_dir,rte_rrtmgp_folder)
@@ -23,5 +36,5 @@ end
 
 cd(data_dir) do
   rm(data_dir_tar; force=true)
-  RRTMGP.compress_targz(data_dir_tar)
+  compress_targz(data_dir_tar)
 end

--- a/src/Misc.jl
+++ b/src/Misc.jl
@@ -13,19 +13,6 @@ function extract_targz(file)
   end
 end
 
-"""
-    compress_targz(file)
-
-Platform-independent file compression
-"""
-function compress_targz(file)
-  if Sys.iswindows()
-    error("Needs to be implemented")
-  else
-    run(`tar -zcvf $file $(readdir())`)
-  end
-end
-
 function data_folder_rrtmgp()
   register(DataDep("rte-rrtmgp",
                    "data for rte-rrtmgp repo",


### PR DESCRIPTION
Moves `compress_targz` outside of src/, since it's only used in OriginalRRTMGP/