### PR TITLE
Remove some passed indexes

### DIFF
--- a/src/rrtmgp/GasOptics_kernels.jl
+++ b/src/rrtmgp/GasOptics_kernels.jl
@@ -465,6 +465,9 @@ end
 """
     compute_Planck_source!(...)
 
+Compute internal (Planck) source functions at layers and levels,
+which depend on mapping from spectral space that creates k-distribution.
+
  - `ics` interpolation coefficients, see [`InterpolationCoefficients`](@ref)
 
 integer,                                    intent(in) :: ncol, nlay, nbnd, ngpt
@@ -543,7 +546,7 @@ function compute_Planck_source!(ncol, nlay, nbnd, ngpt,
   # Compute surface source irradiance for g-point, equals band irradiance x fraction for g-point
   #
   @inbounds for icol in 1:ncol
-    planck_function[1:nbnd,1,icol] = interpolate1D(tsfc[icol], temp_ref_min, totplnk_delta, totplnk)
+    planck_function[1:nbnd,1,icol] .= interpolate1D(tsfc[icol], temp_ref_min, totplnk_delta, totplnk)
     #
     # Map to g-points
     #
@@ -559,7 +562,7 @@ function compute_Planck_source!(ncol, nlay, nbnd, ngpt,
   @inbounds for icol in 1:ncol
     @inbounds for ilay in 1:nlay
       # Compute layer source irradiance for g-point, equals band irradiance x fraction for g-point
-      planck_function[1:nbnd,ilay,icol] = interpolate1D(tlay[icol,ilay], temp_ref_min, totplnk_delta, totplnk)
+      planck_function[1:nbnd,ilay,icol] .= interpolate1D(tlay[icol,ilay], temp_ref_min, totplnk_delta, totplnk)
       #
       # Map to g-points
       #
@@ -575,9 +578,9 @@ function compute_Planck_source!(ncol, nlay, nbnd, ngpt,
 
   # compute level source irradiances for each g-point, one each for upward and downward paths
   @inbounds for icol in 1:ncol
-    planck_function[1:nbnd,       1,icol] = interpolate1D(tlev[icol,     1], temp_ref_min, totplnk_delta, totplnk)
+    planck_function[1:nbnd,       1,icol] .= interpolate1D(tlev[icol,     1], temp_ref_min, totplnk_delta, totplnk)
     @inbounds for ilay in 1:nlay
-      planck_function[1:nbnd,ilay+1,icol] = interpolate1D(tlev[icol,ilay+1], temp_ref_min, totplnk_delta, totplnk)
+      planck_function[1:nbnd,ilay+1,icol] .= interpolate1D(tlev[icol,ilay+1], temp_ref_min, totplnk_delta, totplnk)
       #
       # Map to g-points
       #

--- a/src/rte/OpticalProps.jl
+++ b/src/rte/OpticalProps.jl
@@ -124,8 +124,8 @@ Holds absorption optical depth `τ`, used in calculations accounting for extinct
 $(DocStringExtensions.FIELDS)
 """
 struct OneScalar{FT,I} <: AbstractOpticalPropsArry{FT,I}
-  base
-  τ#::Array{FT,3}
+  base::OpticalPropsBase{FT}
+  τ::Array{FT,3}
 end
 
 OneScalar(base::OpticalPropsBase{FT}, ps::ProblemSize{I}) where {FT<:AbstractFloat,I<:Int} =
@@ -140,10 +140,10 @@ Holds extinction optical depth `τ`, single-scattering albedo (`ssa`), and asymm
 $(DocStringExtensions.FIELDS)
 """
 struct TwoStream{FT,I} <: AbstractOpticalPropsArry{FT,I}
-  base
-  τ#::Array{FT,3}
-  ssa#::Array{FT,3}
-  g#::Array{FT,3}
+  base::OpticalPropsBase{FT}
+  τ::Array{FT,3}
+  ssa::Array{FT,3}
+  g::Array{FT,3}
 end
 
 TwoStream(base::OpticalPropsBase{FT}, ps::ProblemSize{I}) where {FT<:AbstractFloat,I<:Int} =


### PR DESCRIPTION
 - Removes some indexes passed as args
 - Adds type restrictions to optical properties
 - Convert loop to `repeat`
 - Remove temp array `tlev_arr`
 