### PR TITLE
Add AtmosphericStates

### DIFF
--- a/src/RRTMGP.jl
+++ b/src/RRTMGP.jl
@@ -14,6 +14,7 @@ include(joinpath("rte","RTESolver.jl"))
 include(joinpath("rrtmgp","PhysicalConstants.jl"))
 include(joinpath("rrtmgp","Gases.jl"))
 include(joinpath("rrtmgp","GasConcentrations.jl"))
+include(joinpath("rrtmgp","AtmosphericStates.jl"))
 include(joinpath("rrtmgp","GasOptics.jl"))
 
 end # module

--- a/src/rrtmgp/AtmosphericStates.jl
+++ b/src/rrtmgp/AtmosphericStates.jl
@@ -1,0 +1,101 @@
+"""
+    AtmosphericStates
+
+Atmospheric conditions used as inputs to RRTMGP.
+"""
+module AtmosphericStates
+
+using DocStringExtensions
+
+using ..GasConcentrations
+
+export AtmosphericState
+
+abstract type AbstractAtmosphericState{AbstractFloat,Integer} end
+
+"""
+    SimpleGrid{FT}
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct SimpleGrid{FT}
+  z
+end
+
+function interpolate_temperature(p_lay::Array{FT},
+                                 p_lev::Array{FT},
+                                 t_lay::Array{FT},
+                                 ncol::I,
+                                 nlay::I) where {FT<:AbstractFloat,I<:Int}
+  t_lev = zeros(FT, ncol,nlay+1)
+  # Interpolate temperature to levels if not provided
+  #   Interpolation and extrapolation at boundaries is weighted by pressure
+  #
+  for icol = 1:ncol
+     t_lev[icol,1] = t_lay[icol,1] +
+                    (p_lev[icol,1]-p_lay[icol,1])*
+                    (t_lay[icol,2]-t_lay[icol,1])/
+                    (p_lay[icol,2]-p_lay[icol,1])
+  end
+  for ilay in 2:nlay
+    for icol in 1:ncol
+       t_lev[icol,ilay] = (p_lay[icol,ilay-1]*t_lay[icol,ilay-1]*
+                          (p_lev[icol,ilay]-p_lay[icol,ilay]) +
+                           p_lay[icol,ilay]*t_lay[icol,ilay]*
+                          (p_lay[icol,ilay-1]-p_lev[icol,ilay]))/
+                          (p_lev[icol,ilay]*(p_lay[icol,ilay-1] - p_lay[icol,ilay]))
+    end
+  end
+  for icol = 1:ncol
+     t_lev[icol,nlay+1] = t_lay[icol,nlay] +
+                         (p_lev[icol,nlay+1]-p_lay[icol,nlay])*
+                         (t_lay[icol,nlay]-t_lay[icol,nlay-1])/
+                         (p_lay[icol,nlay]-p_lay[icol,nlay-1])
+  end
+  return t_lev
+end
+
+"""
+    AtmosphericState{FT}
+
+as = AtmosphericState(gas_conc,p_lay, p_lev, t_lay, t_lev)
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct AtmosphericState{FT,I} <: AbstractAtmosphericState{FT,I}
+  "Grid over which vertical integration is performed"
+  grid::SimpleGrid{FT}
+  "Gas concentrations, in the form of volume mixing ratios"
+  gas_conc::GasConcs{FT,I}
+  "layer pressures [Pa, mb]; (ncol,nlay)"
+  p_lay::Array{FT,2}
+  "level pressures [Pa, mb]; (ncol,nlay+1)"
+  p_lev::Array{FT,2}
+  "layer temperatures [K]; (ncol,nlay)"
+  t_lay::Array{FT,2}
+  "level temperatures [K]; (ncol,nlay+1)"
+  t_lev::Array{FT,2}
+  "Indicates whether arrays are ordered in the vertical with 1 at the top or the bottom of the domain."
+  top_at_1::Bool
+  nlay::I
+  ncol::I
+  function AtmosphericState(gas_conc::GasConcs{FT,I},
+                            p_lay::Array{FT,2},
+                            p_lev::Array{FT,2},
+                            t_lay::Array{FT,2},
+                            t_lev::Union{Array{FT,2},Nothing}=nothing) where {I<:Int,FT<:AbstractFloat}
+    nlay = size(p_lay, 2)
+    ncol = size(p_lay, 1)
+    if t_lev==nothing
+      t_lev = interpolate_temperature(p_lay, p_lev, t_lay, ncol, nlay)
+    end
+    # Are the arrays ordered in the vertical with 1 at the top or the bottom of the domain?
+    top_at_1 = p_lay[1, 1] < p_lay[1, nlay]
+    grid = SimpleGrid{FT}(p_lay)
+    return new{FT,I}(grid,gas_conc,p_lay,p_lev,t_lay,t_lev,top_at_1,nlay,ncol)
+  end
+end
+
+end #module

--- a/src/rrtmgp/Gases.jl
+++ b/src/rrtmgp/Gases.jl
@@ -8,7 +8,7 @@ export AbstractGas
 export chem_name, rfmip_name
 export h2o, o3, no2, co2, CCl4, CH3Br, CH3Cl, n2o, co, ch4, o2, n2, cfc22
 export ccl4, cfc11, cfc12, hfc143a, hfc125, hfc23, hfc32, hfc134a, cf4, ch3br, ch3cl # not tested
-export h2o_frgn, h2o_self
+export h2o_frgn, h2o_self # TODO: figure out what these gases are
 export UncaughtGas
 
 abstract type AbstractGas end
@@ -37,8 +37,8 @@ struct hfc134a     <: AbstractGas end # Not tested
 struct cf4         <: AbstractGas end # Not tested
 struct ch3br       <: AbstractGas end # Not tested
 struct ch3cl       <: AbstractGas end # Not tested
-struct h2o_frgn    <: AbstractGas end # Not tested
-struct h2o_self    <: AbstractGas end # Not tested
+struct h2o_frgn    <: AbstractGas end # TODO: figure out what these gases are
+struct h2o_self    <: AbstractGas end # TODO: figure out what these gases are
 struct UncaughtGas <: AbstractGas end
 
 chem_name(g::AbstractGas) = first(split(string(g), "("))
@@ -82,12 +82,5 @@ rfmip_name(::ch3cl)       = "methyl_chloride"
 rfmip_name(::h2o_frgn)    = "h2o_frgn"
 rfmip_name(::h2o_self)    = "h2o_self"
 rfmip_name(::UncaughtGas) = "UncaughtGas"
-
-# struct GasSet{N,T<:NTuple{N,AbstractGas}}
-#   gases::T
-# end
-
-# GasSet(g::NTuple{N,AbstractGas}) where {N} = GasSet{N,typeof(g)}(g)
-# GasSet(g::AbstractGas...) = GasSet(g)
 
 end # module


### PR DESCRIPTION
 - Adds `AtmosphericState`, and utilizes it for drivers

Some performance may be lost since this requires copying new `AtmosphericState`'s for each block in the clear sky drivers, but this nicely encapsulates some of the required input data, and will help simplify function interfaces.