### PR TITLE
Move `t_sfc` into `AtmosState`, and `toa_src` out of `GasOptics`

### DIFF
--- a/test/rfmip_clear_sky_lw.jl
+++ b/test/rfmip_clear_sky_lw.jl
@@ -87,7 +87,7 @@ function rfmip_clear_sky_lw(ds, optical_props_constructor; compile_first=false)
   # Read the gas concentrations and surface properties
   #
   gas_conc_array = read_and_block_gases_ty(ds[:rfmip], block_size, kdist_gas_names)
-  sfc_emis_all, sfc_t_all = read_and_block_lw_bc(ds[:rfmip], block_size)
+  sfc_emis_all, t_sfc_all = read_and_block_lw_bc(ds[:rfmip], block_size)
 
   #
   # Read k-distribution information. load_and_init() reads data from netCDF and calls
@@ -151,17 +151,13 @@ function rfmip_clear_sky_lw(ds, optical_props_constructor; compile_first=false)
     p_lev = p_lev_all[:,:,b]
     t_lay = t_lay_all[:,:,b]
     t_lev = t_lev_all[:,:,b]
-    sfc_t = sfc_t_all[:,  b]
-    as = AtmosphericState(gas_conc, p_lay, p_lev, t_lay, t_lev, k_dist.ref)
+    t_sfc = t_sfc_all[:,  b]
+    as = AtmosphericState(gas_conc, p_lay, p_lev, t_lay, t_lev, k_dist.ref, nothing, t_sfc)
 
     fluxes.flux_up .= FT(0)
     fluxes.flux_dn .= FT(0)
 
-    gas_optics_int!(k_dist,
-                    as,
-                    sfc_t,
-                    optical_props,
-                    source)
+    gas_optics!(k_dist, as, optical_props, source)
 
     rte_lw!(optical_props,
             as.top_at_1,

--- a/test/rfmip_clear_sky_sw.jl
+++ b/test/rfmip_clear_sky_sw.jl
@@ -158,11 +158,10 @@ function rfmip_clear_sky_sw(ds, optical_props_constructor; compile_first=false)
     fluxes.flux_up .= FT(0)
     fluxes.flux_dn .= FT(0)
 
-    @timeit to "gas_optics_ext!" gas_optics_ext!(k_dist,
-                                                 as,
-                                                 optical_props,
-                                                 toa_flux,
-                                                 b==b_tot)
+    @timeit to "gas_optics!" gas_optics!(k_dist, as, optical_props, b==b_tot)
+
+    check_extent(toa_flux, (as.ncol, ngpt), "toa_flux")
+    toa_flux .= repeat(k_dist.solar_src', as.ncol)
     # Boundary conditions
     #   (This is partly to show how to keep work on GPUs using OpenACC in a host application)
     # What's the total solar irradiance assumed by RRTMGP?


### PR DESCRIPTION
 - Moves `t_sfc` into `AtmosState`
 - Moves `toa_src` out of `GasOptics`, since `toa_src` is more related to RTE than gas optics