### PR TITLE
Split ReferenceState in k-dist, rename k-dists

### DIFF
--- a/docs/src/RRTMGP/GasOptics.md
+++ b/docs/src/RRTMGP/GasOptics.md
@@ -7,7 +7,7 @@ CurrentModule = RRTMGP.GasOptics
 ```@docs
 GasOpticsAux
 GasOpticsVars
-InternalSourceGasOptics
-ExternalSourceGasOptics
+KDistributionLongwave
+KDistributionShortwave
 ```
 

--- a/src/rrtmgp/AtmosphericStates.jl
+++ b/src/rrtmgp/AtmosphericStates.jl
@@ -141,7 +141,7 @@ struct AtmosphericState{FT,I} <: AbstractAtmosphericState{FT,I}
                             p_lev::Array{FT,2},
                             t_lay::Array{FT,2},
                             t_lev::Union{Array{FT,2},Nothing},
-                            ref::ReferenceState,
+                            ref::ReferenceStateProfile,
                             col_dry::Union{Array{FT,2},Nothing}=nothing,
                             t_sfc::Union{Vector{FT},Nothing}=nothing) where {I<:Int,FT<:AbstractFloat}
     nlay = size(p_lay, 2)

--- a/src/rrtmgp/GasOptics_kernels.jl
+++ b/src/rrtmgp/GasOptics_kernels.jl
@@ -46,7 +46,8 @@ function interpolation!(ics::InterpolationCoefficients{FT,I},
                         npres::I,
                         ntemp::I,
                         flavor::Array{I},
-                        ref::ReferenceState{FT},
+                        vmr::AbstractArray{FT},
+                        ref::ReferenceStateProfile{FT},
                         play::Array{FT},
                         tlay::Array{FT},
                         col_gas::AbstractArray{FT}) where {I<:Int,B<:Bool,FT<:AbstractFloat}
@@ -83,8 +84,8 @@ function interpolation!(ics::InterpolationCoefficients{FT,I},
           # compute interpolation fractions needed for lower, then upper reference temperature level
           # compute binary species parameter (η) for flavor and temperature and
           #  associated interpolation index and factors
-          ratio_η_half = ref.vmr[itropo,igases[1],(ics.jtemp[icol,ilay]+itemp-1)] /
-                         ref.vmr[itropo,igases[2],(ics.jtemp[icol,ilay]+itemp-1)]
+          ratio_η_half = vmr[itropo,igases[1],(ics.jtemp[icol,ilay]+itemp-1)] /
+                         vmr[itropo,igases[2],(ics.jtemp[icol,ilay]+itemp-1)]
           col_mix[itemp,iflav,icol,ilay] = col_gas[icol,ilay,igases[1]] + ratio_η_half * col_gas[icol,ilay,igases[2]]
           η = fmerge(col_gas[icol,ilay,igases[1]] / col_mix[itemp,iflav,icol,ilay], FT(0.5),
                       col_mix[itemp,iflav,icol,ilay] > FT(2) * floatmin(FT))

--- a/src/rrtmgp/ReferenceStates.jl
+++ b/src/rrtmgp/ReferenceStates.jl
@@ -9,18 +9,18 @@ using DocStringExtensions
 using OffsetArrays
 using ..Gases
 using ..Utilities
-export ReferenceState
+export ReferenceStateProfile, ReferenceState
 export get_press_min
 
 """
-    ReferenceState{FT}
+    ReferenceStateProfile{FT}
 
 Reference state variables for look-up tables / interpolation
 
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct ReferenceState{FT}
+struct ReferenceStateProfile{FT}
   "Pressure"
   press::Vector{FT}
   "Log of pressure"
@@ -39,16 +39,9 @@ struct ReferenceState{FT}
   press_log_delta::FT
   temp_delta::FT
   press_trop_log::FT
-  vmr::AbstractArray{FT,3}   # vmr(lower or upper atmosphere, gas, temp)
-  function ReferenceState(press::Array{FT},
-                          temp::Array{FT},
-                          press_ref_trop::FT,
-                          vmr_ref::Array{FT},
-                          available_gases::Vector{AbstractGas},
-                          gas_names::Vector{AbstractGas}) where {FT<:AbstractFloat}
-
-    gas_is_present = map(x->x in available_gases, gas_names)
-    ngas = count(gas_is_present)
+  function ReferenceStateProfile(press::Array{FT},
+                                 temp::Array{FT},
+                                 press_ref_trop::FT) where {FT<:AbstractFloat}
 
     press_log = log.(press)
     # TODO: remove assumption of ordering
@@ -62,14 +55,6 @@ struct ReferenceState{FT}
     press_log_delta = (log(press_min)-log(press_max))/(length(press)-1)
     temp_delta      = (temp_max-temp_min)/(length(temp)-1)
 
-    vmr_ref_red = OffsetArray{FT}(undef, 1:size(vmr_ref, 1),0:ngas, 1:size(vmr_ref, 3))
-
-    # Gas 0 is used in single-key species method, set to 1.0 (col_dry)
-    vmr_ref_red[:,0,:] = vmr_ref[:,1,:]
-    for i = 1:ngas
-      idx = loc_in_array(available_gases[i], gas_names)
-      vmr_ref_red[:,i,:] = vmr_ref[:,idx+1,:]
-    end
     return new{FT}(press,
                    press_log,
                    temp,
@@ -79,16 +64,84 @@ struct ReferenceState{FT}
                    temp_max,
                    press_log_delta,
                    temp_delta,
-                   press_trop_log,
-                   vmr_ref_red)
+                   press_trop_log)
   end
 end
 
 """
-    get_press_min(ref::ReferenceState)
+    ReferenceStatePerGridPoint{FT}
+
+Reference state variables for look-up tables / interpolation
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct ReferenceStatePerGridPoint{FT}
+  "Pressure"
+  press::FT
+  "Log of pressure"
+  press_log::FT
+  "Temperature"
+  temp::FT
+  "Minimum of pressure"
+  press_min::FT
+  "Maximum of pressure"
+  press_max::FT
+  "Minimum of temperature"
+  temp_min::FT
+  "Maximum of temperature"
+  temp_max::FT
+  "Maximum of temperature"
+  press_log_delta::FT
+  temp_delta::FT
+  press_trop_log::FT
+end
+ReferenceStatePerGridPoint(ref::ReferenceStateProfile) =
+  ReferenceStatePerGridPoint.(press,
+                              press_log,
+                              temp,
+                              Ref(press_min),
+                              Ref(press_max),
+                              Ref(temp_min),
+                              Ref(temp_max),
+                              Ref(press_log_delta),
+                              Ref(temp_delta),
+                              Ref(press_trop_log))
+
+"""
+    ReferenceState{FT}
+
+Reference state variables for look-up tables / interpolation
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct ReferenceState{FT}
+  vmr::AbstractArray{FT,3}   # vmr(lower or upper atmosphere, gas, temp)
+  function ReferenceState(vmr_ref::Array{FT},
+                          available_gases::Vector{AbstractGas},
+                          gas_names::Vector{AbstractGas}) where {FT<:AbstractFloat}
+
+    gas_is_present = map(x->x in available_gases, gas_names)
+    ngas = count(gas_is_present)
+
+    vmr_ref_red = OffsetArray{FT}(undef, 1:size(vmr_ref, 1),0:ngas, 1:size(vmr_ref, 3))
+
+    # Gas 0 is used in single-key species method, set to 1.0 (col_dry)
+    vmr_ref_red[:,0,:] = vmr_ref[:,1,:]
+    for i = 1:ngas
+      idx = loc_in_array(available_gases[i], gas_names)
+      vmr_ref_red[:,i,:] = vmr_ref[:,idx+1,:]
+    end
+    return new{FT}(vmr_ref_red)
+  end
+end
+
+"""
+    get_press_min(ref::ReferenceStateProfile)
 
 Minimum pressure on the interpolation grids
 """
-get_press_min(ref::ReferenceState) = ref.press_min
+get_press_min(ref::ReferenceStateProfile) = ref.press_min
 
 end

--- a/src/rte/OpticalProps.jl
+++ b/src/rte/OpticalProps.jl
@@ -76,19 +76,19 @@ Base class for optical properties. Describes the spectral
 discretization including the wavenumber limits of each band
 (spectral region) and the mapping between g-points and bands.
 
- - (begin g-point, end g-point) = band2gpt(2,band)
- - band = gpt2band(g-point)
- - (upper and lower wavenumber by band) = band_lims_wvn(2,band)
-
 # Fields
 $(DocStringExtensions.FIELDS)
 """
 struct OpticalPropsBase{FT,I} <: AbstractOpticalProps{FT,I}
+  "begin g-point, end g-point"
   band2gpt::Array{I,2}
+  "band = gpt2band[g-point]"
   gpt2band::Array{I,1}
+  "(upper and lower wavenumber by band) = band_lims_wvn[2,band]"
   band_lims_wvn::Array{FT,2}
+  "name of particular optical properties"
   name::AbstractString
-  function OpticalPropsBase(name, band_lims_wvn::Array{FT}, band_lims_gpt=nothing) where FT
+  function OpticalPropsBase(name::AbstractString, band_lims_wvn::Array{FT}, band_lims_gpt=nothing) where FT
     @assert size(band_lims_wvn,1) == 2
     @assert !any(band_lims_wvn.<FT(0))
     band_lims_gpt_lcl = Array{Int}(undef, 2, size(band_lims_wvn, 2))

--- a/test/rfmip_clear_sky_lw.jl
+++ b/test/rfmip_clear_sky_lw.jl
@@ -94,7 +94,7 @@ function rfmip_clear_sky_lw(ds, optical_props_constructor; compile_first=false)
   # Read k-distribution information. load_and_init() reads data from netCDF and calls
   #   k_dist%init(); users might want to use their own reading methods
   #
-  k_dist = load_and_init(ds[:k_dist], FT, gas_conc_array[1].gas_names)
+  k_dist, ref_prof = load_and_init(ds[:k_dist], FT, gas_conc_array[1].gas_names)
   @assert source_is_internal(k_dist)
 
   nbnd = get_nband(k_dist.optical_props)
@@ -110,9 +110,9 @@ function rfmip_clear_sky_lw(ds, optical_props_constructor; compile_first=false)
   #   This introduces an error but shows input sanitizing.
   #
   if top_at_1
-    p_lev_all[:,1,:] .= get_press_min(k_dist.ref) + eps(FT)
+    p_lev_all[:,1,:] .= get_press_min(ref_prof) + eps(FT)
   else
-    p_lev_all[:,nlay+1,:] .= get_press_min(k_dist.ref) + eps(FT)
+    p_lev_all[:,nlay+1,:] .= get_press_min(ref_prof) + eps(FT)
   end
 
   #
@@ -153,12 +153,12 @@ function rfmip_clear_sky_lw(ds, optical_props_constructor; compile_first=false)
     t_lay = t_lay_all[:,:,b]
     t_lev = t_lev_all[:,:,b]
     t_sfc = t_sfc_all[:,  b]
-    as = AtmosphericState(gas_conc, p_lay, p_lev, t_lay, t_lev, k_dist.ref, nothing, t_sfc)
+    as = AtmosphericState(gas_conc, p_lay, p_lev, t_lay, t_lev, ref_prof, nothing, t_sfc)
 
     fluxes.flux_up .= FT(0)
     fluxes.flux_dn .= FT(0)
 
-    gas_optics!(k_dist, as, optical_props, source)
+    gas_optics!(k_dist, as, ref_prof, optical_props, source)
 
     bcs = LongwaveBCs(sfc_emis_spec)
 


### PR DESCRIPTION
 - Splits `ReferenceState` into `ReferenceState` and `ReferenceStateProfiles`, where `ReferenceState` has no spatial information.
 - Renames `InternalSourceGasOptics`->`KDistributionLongwave`
 - Renames `ExternalSourceGasOptics`->`KDistributionShortwave`
 - Adds some type restrictions
 - Cleans up some documentation
 - Adds `ReferenceStatePerGridPoint`

`AbstractGasOptics` (`KDistributionLongwave` and `KDistributionShortwave`) are now spatially independent and can be passed in by reference when called from CLIMA.