### PR TITLE
Add MeshOrientations

### DIFF
--- a/src/MeshOrientations.jl
+++ b/src/MeshOrientations.jl
@@ -1,0 +1,42 @@
+"""
+    MeshOrientations
+
+Mesh orientation.
+"""
+module MeshOrientations
+
+using DocStringExtensions
+
+export MeshOrientation
+
+"""
+    MeshOrientation{FT}
+
+Mesh orientation
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct MeshOrientation{I}
+  "Indicates whether arrays are ordered in the vertical with 1 at the top or the bottom of the domain."
+  top_at_1::Bool
+  "i-th level at the top of the domain"
+  ilev_top::I
+  "i-th level at the bottom of the domain"
+  ilev_bot::I
+  "i-th layer at the top of the domain"
+  ilay_top::I
+  "i-th layer at the bottom of the domain"
+  ilay_bot::I
+  function MeshOrientation(top_at_1::Bool, nlay::I) where {I<:Int}
+    ilev_top =  top_at_1 ? 1 : nlay+1
+    ilev_bot = !top_at_1 ? 1 : nlay+1
+
+    ilay_top =  top_at_1 ? 1 : nlay
+    ilay_bot = !top_at_1 ? 1 : nlay
+
+    return new{I}(top_at_1, ilev_top, ilev_bot, ilay_top, ilay_bot)
+  end
+end
+
+end #module

--- a/src/RRTMGP.jl
+++ b/src/RRTMGP.jl
@@ -3,6 +3,7 @@ module RRTMGP
 include("Misc.jl")
 include("FortranIntrinsics.jl")
 include("Utilities.jl")
+include("MeshOrientations.jl")
 
 include(joinpath("rte","AngularDiscretizations.jl"))
 include(joinpath("rte","SolarZenithAngle.jl"))

--- a/src/rrtmgp/GasOptics.jl
+++ b/src/rrtmgp/GasOptics.jl
@@ -267,23 +267,6 @@ Base.convert(::Type{Array{InterpolationCoefficientsPGP}}, data::InterpolationCoe
                                       data.col_mix[:,:,i,j]) for i in 1:size(data.jtemp,1), j in 1:size(data.jtemp,2)]
 
 """
-    get_ngas(this::AbstractGasOptics)
-
-Number of gases registered in the spectral configuration
-"""
-get_ngas(this::AbstractGasOptics) = length(this.gas_names)
-
-
-"""
-    get_nflav(this::AbstractGasOptics)
-
-Number of distinct major gas pairs in the spectral bands (referred to as
-"flavors" - all bands have a flavor even if there is one or no major gas)
-"""
-get_nflav(this::AbstractGasOptics) = size(this.flavor, 2)
-
-
-"""
     gas_optics!(this::KDistributionLongwave{FT,I},
                 as::AtmosphericState{FT,I},
                 optical_props::AbstractOpticalPropsArry{FT,I},
@@ -869,11 +852,16 @@ function combine_and_reorder!(τ::Array{FT,3},
 end
 
 #####
-##### Sizes of tables: pressure, temperate, η (mixing fraction)
-#####   Equivalent routines for the number of gases and flavors
-#####   (get_ngas(), get_nflav()) are defined above because they're
-#####   used in function definitions
+##### Sizes of tables: pressure, temperate, η (mixing fraction), nflav
 #####
+
+"""
+    get_nflav(this::AbstractGasOptics)
+
+Number of distinct major gas pairs in the spectral bands (referred to as
+"flavors" - all bands have a flavor even if there is one or no major gas)
+"""
+get_nflav(this::AbstractGasOptics) = size(this.flavor, 2)
 
 """
     get_neta(this::AbstractGasOptics)

--- a/src/rrtmgp/GasOptics_kernels.jl
+++ b/src/rrtmgp/GasOptics_kernels.jl
@@ -230,7 +230,7 @@ function gas_optical_depths_minor!(τ::Array{FT,3},
                                    as::AtmosphericState{FT,I},
                                    ics::InterpolationCoefficients{FT,I},
                                    itropo::I) where {FT<:AbstractFloat, I<:Int}
-  @unpack_fields as col_gas t_lay p_lay tropo_lims
+  @unpack_fields as col_gas t_lay p_lay tropo_lims gt_0_tropo_lims
   @unpack_fields ics jtemp fminor j_η
   @unpack_fields go gpoint_flavor lower lower_aux upper upper_aux gas_names
   idx_h2o = loc_in_array(h2o(), gas_names)
@@ -247,7 +247,7 @@ function gas_optical_depths_minor!(τ::Array{FT,3},
   # First check skips the routine entirely if all columns are out of bounds...
   #
 
-  if any(tropo_lims[:,1,itropo] .> 0)
+  if gt_0_tropo_lims[itropo]
     @inbounds for imnr in 1:size(scale_by_complement,1) # loop over minor absorbers in each band
       kminor_start_imnr = kminor_start[imnr]
       @inbounds for icol in 1:ncol
@@ -391,7 +391,7 @@ function compute_Planck_source!(sources::SourceFuncLongWave{FT,I},
   @unpack_fields go ref totplnk_delta totplnk gpoint_flavor planck_frac optical_props
   @unpack_fields ref temp_min
   @unpack_fields sources sfc_source lay_source lev_source_inc lev_source_dec p_frac
-  @unpack_fields as t_lay t_lev t_sfc sfc_lay tropo
+  @unpack_fields as t_lay t_lev t_sfc mesh_orientation tropo
   @unpack_fields ics jtemp j_η jpress fmajor
 
   ncol  = get_ncol(sources)
@@ -429,7 +429,7 @@ function compute_Planck_source!(sources::SourceFuncLongWave{FT,I},
         scaling = SVector{2,FT}(1,1)
 
         # interpolation in temperature, pressure, and η
-        @inbounds for igpt in gptS:gptE
+        @inbounds for igpt in gpt_range(optical_props, ibnd)
           τ_local = interpolate3D(scaling,
                               fmajor_sm1,
                               fmajor_sm2,
@@ -454,10 +454,8 @@ function compute_Planck_source!(sources::SourceFuncLongWave{FT,I},
     # Map to g-points
     #
     @inbounds for ibnd in 1:nbnd
-      gptS = band_lims_gpt[1, ibnd]
-      gptE = band_lims_gpt[2, ibnd]
-      @inbounds for igpt in gptS:gptE
-        sfc_source[icol, igpt] = p_frac[icol,sfc_lay,igpt] * planck_function[ibnd, 1, icol]
+      @inbounds for igpt in gpt_range(optical_props, ibnd)
+        sfc_source[icol, igpt] = p_frac[icol,mesh_orientation.ilay_bot,igpt] * planck_function[ibnd, 1, icol]
       end
     end
   end # icol
@@ -470,9 +468,7 @@ function compute_Planck_source!(sources::SourceFuncLongWave{FT,I},
       # Map to g-points
       #
       @inbounds for ibnd in 1:nbnd
-        gptS = band_lims_gpt[1, ibnd]
-        gptE = band_lims_gpt[2, ibnd]
-        @inbounds for igpt in gptS:gptE
+        @inbounds for igpt in gpt_range(optical_props, ibnd)
           lay_source[icol,ilay,igpt] = p_frac[icol,ilay,igpt] * planck_function[ibnd,ilay,icol]
         end
       end
@@ -488,9 +484,7 @@ function compute_Planck_source!(sources::SourceFuncLongWave{FT,I},
       # Map to g-points
       #
       @inbounds for ibnd in 1:nbnd
-        gptS = band_lims_gpt[1, ibnd]
-        gptE = band_lims_gpt[2, ibnd]
-        @inbounds for igpt in gptS:gptE
+        @inbounds for igpt in gpt_range(optical_props, ibnd)
           lev_source_inc[icol,ilay,igpt] = p_frac[icol,ilay,igpt] * planck_function[ibnd,ilay+1,icol]
           lev_source_dec[icol,ilay,igpt] = p_frac[icol,ilay,igpt] * planck_function[ibnd,ilay,  icol]
         end

--- a/src/rrtmgp/ReferenceStates.jl
+++ b/src/rrtmgp/ReferenceStates.jl
@@ -38,9 +38,12 @@ struct ReferenceState{FT} <: AbstractReferenceState{FT}
   temp_max::FT
   "Maximum of temperature"
   press_log_delta::FT
+  "temperature change between surface and top of atmosphere"
   temp_delta::FT
+  "logarithm of tropospheric pressure"
   press_trop_log::FT
-  vmr::Array{FT,3}   # vmr(lower or upper atmosphere, gas, temp)
+  "volume mixing ratio (lower or upper atmosphere, gas, temp)"
+  vmr::Array{FT,3}
   function ReferenceState(press::Array{FT},
                           temp::Array{FT},
                           press_ref_trop::FT,

--- a/src/rte/FluxesBroadBand.jl
+++ b/src/rte/FluxesBroadBand.jl
@@ -31,7 +31,6 @@ end
             gpt_flux_up::Array{FT,3},
             gpt_flux_dn::Array{FT,3},
             spectral_disc::AbstractOpticalProps,
-            top_at_1::Bool,
             gpt_flux_dn_dir::Union{Nothing,Array{FT,3}}=nothing) where FT<:AbstractFloat
 
 Compute `FluxesBroadBand` `this` by summing over the
@@ -40,7 +39,6 @@ spectral dimension, given
  - `gpt_flux_up` upward fluxes by gpoint [W/m2]
  - `gpt_flux_dn` downward fluxes by gpoint [W/m2]
  - `spectral_disc` optical properties containing spectral information
- - `top_at_1` bool indicating at top
 optional:
  - `gpt_flux_dn_dir` downward direct flux
 """
@@ -48,7 +46,6 @@ function reduce!(this::FluxesBroadBand,
                  gpt_flux_up::Array{FT,3},
                  gpt_flux_dn::Array{FT,3},
                  spectral_disc::AbstractOpticalProps,
-                 top_at_1::Bool,
                  gpt_flux_dn_dir::Union{Nothing,Array{FT,3}}=nothing) where FT<:AbstractFloat
 
   ncol,nlev,ngpt = size(gpt_flux_up)

--- a/src/rte/FluxesByBand.jl
+++ b/src/rte/FluxesByBand.jl
@@ -29,7 +29,6 @@ end
             gpt_flux_up::Array{FT,3},
             gpt_flux_dn::Array{FT,3},
             spectral_disc::AbstractOpticalProps,
-            top_at_1::Bool,
             gpt_flux_dn_dir::Union{Nothing,Array{FT,3}}=nothing)
 
 Reduces fluxes by-band to broadband in `FluxesByBand` `this`, given
@@ -37,7 +36,6 @@ Reduces fluxes by-band to broadband in `FluxesByBand` `this`, given
  - `gpt_flux_up` fluxes by gpoint [W/m2]
  - `gpt_flux_dn` fluxes by gpoint [W/m2]
  - `spectral_disc` spectral discretization, see [`AbstractOpticalProps`](@ref)
- - `top_at_1` bool indicating at top
 and, optionally,
  - `gpt_flux_dn_dir` direct flux downward
 """
@@ -45,7 +43,6 @@ function reduce!(this::FluxesByBand,
                  gpt_flux_up::Array{FT,3},
                  gpt_flux_dn::Array{FT,3},
                  spectral_disc::AbstractOpticalProps,
-                 top_at_1::Bool,
                  gpt_flux_dn_dir::Union{Nothing,Array{FT,3}}=nothing) where {FT<:AbstractFloat}
   ncol, nlev = size(gpt_flux_up)
   ngpt = get_ngpt(spectral_disc)
@@ -55,7 +52,7 @@ function reduce!(this::FluxesByBand,
   # Compute broadband fluxes
   #   This also checks that input arrays are consistently sized
   #
-  reduce_broadband!(this.fluxes_broadband, gpt_flux_up, gpt_flux_dn, spectral_disc, top_at_1, gpt_flux_dn_dir)
+  reduce!(this.fluxes_broadband, gpt_flux_up, gpt_flux_dn, spectral_disc, gpt_flux_dn_dir)
 
   # Check sizes
   @assert size(gpt_flux_up, 3) == ngpt

--- a/src/rte/OpticalProps.jl
+++ b/src/rte/OpticalProps.jl
@@ -38,6 +38,7 @@ export delta_scale!,
        get_band_lims_wavenumber,
        get_gpoint_bands,
        bands_are_equal,
+       gpt_range,
        get_band_lims_gpoint
 
 export get_nband,
@@ -409,6 +410,16 @@ Band associated with a specific g-point
 """
 convert_gpt2band(this::AbstractOpticalProps, gpt::I) where {I<:Int} = convert_gpt2band(this.base)
 convert_gpt2band(this::OpticalPropsBase, gpt::I) where {I<:Int} = this.gpt2band[gpt]
+
+"""
+    gpt_range(this::AbstractOpticalProps)
+
+A range of g-point bands, given the i-th band
+
+ - `this` optical properties, see [`AbstractOpticalProps`](@ref)
+"""
+gpt_range(this::AbstractOpticalProps{FT,I}, ibnd::I) where {FT,I} = gpt_range(this.base, ibnd)
+gpt_range(this::OpticalPropsBase{FT,I}, ibnd::I) where {FT,I<:Int} = this.band2gpt[1,ibnd]:this.band2gpt[2,ibnd]
 
 """
     bands_are_equal(this::AbstractOpticalProps{FT}, that::AbstractOpticalProps{FT}) where FT

--- a/test/allsky.jl
+++ b/test/allsky.jl
@@ -105,8 +105,6 @@ function all_sky(ds; use_luts=false, λ_string="", compile_first=false)
     atmos = OneScalar(k_dist.optical_props, ncol, nlay, ngpt)
   end
 
-  top_at_1 = p_lay[1, 1] < p_lay[1, nlay]
-
   #  Boundary conditions depending on whether the k-distribution being supplied
   #   is LW or SW
   if is_sw
@@ -187,7 +185,7 @@ function all_sky(ds; use_luts=false, λ_string="", compile_first=false)
       increment!(clouds, atmos)
       bcs = LongwaveBCs(sfc_emis)
       rte_lw!(atmos,
-              as.top_at_1,
+              as.mesh_orientation,
               lw_sources,
               bcs,
               fluxes)
@@ -203,7 +201,7 @@ function all_sky(ds; use_luts=false, λ_string="", compile_first=false)
       increment!(clouds, atmos)
       bcs = ShortwaveBCs(toa_flux, sfc_alb_dir, sfc_alb_dif)
       rte_sw!(atmos,
-              as.top_at_1,
+              as.mesh_orientation,
               μ_0,
               bcs,
               fluxes)

--- a/test/allsky_pgp.jl
+++ b/test/allsky_pgp.jl
@@ -111,8 +111,6 @@ function all_sky_pgp(ds; use_luts=false, λ_string="", compile_first=false)
   clouds = get_optical_props(clouds_base, is_sw, ncol, nlay, ngpt)
   atmos  = get_optical_props(k_dist.optical_props, is_sw, ncol, nlay, ngpt)
 
-  top_at_1 = p_lay[1, 1] < p_lay[1, nlay]
-
   #  Boundary conditions depending on whether the k-distribution being supplied
   #   is LW or SW
   if is_sw
@@ -212,7 +210,7 @@ function all_sky_pgp(ds; use_luts=false, λ_string="", compile_first=false)
       increment!(clouds, atmos)
       bcs = LongwaveBCs(sfc_emis)
       rte_lw!(atmos,
-              as.top_at_1,
+              as.mesh_orientation,
               lw_sources,
               bcs,
               fluxes)
@@ -228,7 +226,7 @@ function all_sky_pgp(ds; use_luts=false, λ_string="", compile_first=false)
       increment!(clouds, atmos)
       bcs = ShortwaveBCs(toa_flux, sfc_alb_dir, sfc_alb_dif)
       rte_sw!(atmos,
-              as.top_at_1,
+              as.mesh_orientation,
               μ_0,
               bcs,
               fluxes)

--- a/test/rfmip_clear_sky_lw.jl
+++ b/test/rfmip_clear_sky_lw.jl
@@ -156,7 +156,7 @@ function rfmip_clear_sky_lw(ds, optical_props_constructor; compile_first=false)
     bcs = LongwaveBCs(sfc_emis_spec)
 
     rte_lw!(optical_props,
-            as.top_at_1,
+            as.mesh_orientation,
             source,
             bcs,
             fluxes,

--- a/test/rfmip_clear_sky_lw_pgp.jl
+++ b/test/rfmip_clear_sky_lw_pgp.jl
@@ -171,7 +171,7 @@ function rfmip_clear_sky_lw_pgp(ds, optical_props_constructor; compile_first=fal
     bcs = LongwaveBCs(sfc_emis_spec)
 
     rte_lw!(optical_props,
-            as.top_at_1,
+            as.mesh_orientation,
             source,
             bcs,
             fluxes,

--- a/test/rfmip_clear_sky_sw.jl
+++ b/test/rfmip_clear_sky_sw.jl
@@ -192,7 +192,7 @@ function rfmip_clear_sky_sw(ds, optical_props_constructor; compile_first=false)
     bcs = ShortwaveBCs(toa_flux, sfc_alb_spec, sfc_alb_spec)
 
     @timeit to "rte_sw!" rte_sw!(optical_props,
-                                 as.top_at_1,
+                                 as.mesh_orientation,
                                  μ_0,
                                  bcs,
                                  fluxes)

--- a/test/rfmip_clear_sky_sw_pgp.jl
+++ b/test/rfmip_clear_sky_sw_pgp.jl
@@ -203,7 +203,7 @@ function rfmip_clear_sky_sw_pgp(ds, optical_props_constructor; compile_first=fal
     bcs = ShortwaveBCs(toa_flux, sfc_alb_spec, sfc_alb_spec)
 
     @timeit to "rte_sw!" rte_sw!(optical_props,
-                                 as.top_at_1,
+                                 as.mesh_orientation,
                                  μ_0,
                                  bcs,
                                  fluxes)


### PR DESCRIPTION
 - Adds `MeshOrientation`, which contains `top_at_1` and `i_top`/`i_bot` depending on `top_at_1`'s value
 - Simplify `apply_BC` implementation
 - Removes `AtmosphericStatePGP` constructor, and some other unused functions
 - 