### PR TITLE
Refactor RTE solver kernels

### DIFF
--- a/src/rte/RTESolver.jl
+++ b/src/rte/RTESolver.jl
@@ -122,15 +122,16 @@ function rte_sw!(fluxes::FluxesBroadBand{FT},
   validate!(optical_props)
   if optical_props isa OneScalar
     # Direct beam only
-    sw_solver_noscat!(ncol, nlay, ngpt, mesh_orientation,
-                      optical_props.τ, μ_0,
+    sw_solver_noscat!(mesh_orientation,
+                      optical_props,
+                      μ_0,
                       gpt_flux_dir)
     # No diffuse flux
     # gpt_flux_up .= FT(0)
     # gpt_flux_dn .= FT(0)
   elseif optical_props isa TwoStream
     # two-stream calculation with scattering
-    sw_solver!(ncol, nlay, ngpt, mesh_orientation,
+    sw_solver!(mesh_orientation,
                optical_props,
                μ_0,
                sfc_alb_dir_gpt,
@@ -210,18 +211,18 @@ function rte_lw!(fluxes::FluxesBroadBand{FT},
   # Compute the radiative transfer...
   if optical_props isa OneScalar
 
-    # No scattering two-stream calculation
-    lw_solver_noscat_GaussQuad!(ncol, nlay, ngpt, mesh_orientation,
+    # No scattering
+    lw_solver_noscat_GaussQuad!(mesh_orientation,
                                 angle_disc,
-                                optical_props.τ,
+                                optical_props,
                                 sources,
                                 sfc_emis_gpt,
                                 gpt_flux_up,
                                 gpt_flux_dn)
 
   elseif optical_props isa TwoStream
-    # two-stream calculation with scattering
-    lw_solver!(ncol, nlay, ngpt, mesh_orientation,
+    # With scattering
+    lw_solver!(mesh_orientation,
                optical_props,
                sources,
                sfc_emis_gpt,

--- a/src/rte/RadiativeBoundaryConditions.jl
+++ b/src/rte/RadiativeBoundaryConditions.jl
@@ -31,17 +31,17 @@ $(DocStringExtensions.FIELDS)
 """
 struct ShortwaveBCs{FT} <: AbstractRadiativeBoundaryConditions{FT}
   "top of atmosphere flux"
-  toa_flux::Array{FT}
+  toa_flux::Array{FT,2}
   "surface albedo for specular (direct) radiation"
-  sfc_alb_direct::Array{FT}
+  sfc_alb_direct::Array{FT,2}
   "surface albedo for diffuse radiation"
-  sfc_alb_diffuse::Array{FT}
+  sfc_alb_diffuse::Array{FT,2}
   "incident diffuse flux at top of domain `[W/m2]` `(ncol, ngpt)`"
-  inc_flux_diffuse::Union{Array{FT},Nothing}
-  function ShortwaveBCs(toa_flux::Array{FT},
-                        sfc_alb_direct::Array{FT},
-                        sfc_alb_diffuse::Array{FT},
-                        inc_flux_diffuse::Union{Array{FT},Nothing}=nothing) where {FT<:AbstractFloat}
+  inc_flux_diffuse::Union{Array{FT,2},Nothing}
+  function ShortwaveBCs(toa_flux::Array{FT,2},
+                        sfc_alb_direct::Array{FT,2},
+                        sfc_alb_diffuse::Array{FT,2},
+                        inc_flux_diffuse::Union{Array{FT,2},Nothing}=nothing) where {FT<:AbstractFloat}
     if inc_flux_diffuse ≠ nothing
       # @assert all(size(inc_flux_diffuse) .== (ncol, ngpt)) # TODO: Check sizes somehow
       @assert !any_vals_less_than(inc_flux_diffuse, FT(0))


### PR DESCRIPTION
 - Add ranks to BC structs
 - Propagate optical properties instead of its fields
 - Break down the equation in `lw_source_noscat`