### PR TITLE
Add compat to Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,3 +23,6 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
+
+[compat]
+julia = ">= 1.1"

--- a/test/DataDeps.jl
+++ b/test/DataDeps.jl
@@ -1,9 +1,0 @@
-using Test
-using DataDeps
-using RRTMGP
-
-@testset "DataDep" begin
-  testfolder = RRTMGP.data_folder_rrtmgp_test_val()
-  @test testfolder isa String
-end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,6 @@ for submodule in [
                   "solar_zenith_angle",
                   # "Benchmarks",
                   joinpath("..","PartialImplementations", "PartialImplementations"), # compile only
-                  "DataDeps",
                   ]
 
   println("Testing $submodule")


### PR DESCRIPTION
 - Adds compat to Project.toml
 - Removes DataDeps test, since it doesn't really do anything and recently [hung](https://dev.azure.com/climate-machine/RRTMGP.jl/_build/results?buildId=987&view=logs&j=93056758-5bfb-5750-f113-e720ddefdb4c) during the build.