### PR TITLE
Define eltype on RRTMGPParameters

### DIFF
--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -22,4 +22,6 @@ end
 R_d(ps::ARP) = gas_constant(ps) / molmass_dryair(ps)
 cp_d(ps::ARP) = R_d(ps) / kappa_d(ps)
 
+Base.eltype(::RRTMGPParameters{FT}) where {FT} = FT
+
 end # module


### PR DESCRIPTION
This PR defines eltype on RRTMGPParameters. This is just a convenient function to have defined for parameter structs.