### PR TITLE
update ClimaCoupler env for downstream test

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -45,6 +45,6 @@ jobs:
 
       - if: matrix.package == 'ClimaCoupler.jl'
         run: |
-          julia --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth -e 'using Pkg; Pkg.instantiate()'
-          julia --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth -e 'using Pkg; Pkg.develop(; path = ".")'
-          julia --color=yes --project=ClimaCoupler.jl/experiments/ClimaEarth ClimaCoupler.jl/experiments/ClimaEarth/test/runtests.jl
+          julia --color=yes --project=ClimaCoupler.jl/experiments/AMIP -e 'using Pkg; Pkg.instantiate()'
+          julia --color=yes --project=ClimaCoupler.jl/experiments/AMIP -e 'using Pkg; Pkg.develop(; path = ".")'
+          julia --color=yes --project=ClimaCoupler.jl/experiments/AMIP ClimaCoupler.jl/experiments/test/runtests.jl


### PR DESCRIPTION
To update for the AMIP/CMIP environment split in https://github.com/CliMA/ClimaCoupler.jl/pull/1775. For now I left in the experiments/ClimaEarth/ environment in ClimaCoupler.jl so downstream tests don't break, but it will be removed soon.

## Content
- [x] `experiments/ClimaEarth/` --> `experiments/AMIP/`
- [x] `experiments/AMIP/test/runtests.jl` --> `experiments/test/runtests.jl`