### PR TITLE
Allow CUDA.jl v6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ RRTMGPCUDAExt = "CUDA"
 [compat]
 Adapt = "4"
 Artifacts = "1"
-CUDA = "5.9"
+CUDA = "5.9, 6"
 ClimaComms = "0.5.4, 0.6"
 ClimaParams = "1"
 DocStringExtensions = "0.8, 0.9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RRTMGP"
 uuid = "a01a1ee8-cea4-48fc-987c-fc7878d79da1"
 authors = ["Climate Modeling Alliance"]
-version = "0.21.7"
+version = "0.21.8"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
## Purpose

Allow installation of CUDA.jl v6, and increase version number so that downstream packages can actually install CUDA.jl v6.

It'd be nice to get a new version tagged after this PR is merged, thanks!