### PR TITLE
Fix longwave reader for reduced-resolution (g128) k-distributions

### DIFF
--- a/ext/lookup_constructors.jl
+++ b/ext/lookup_constructors.jl
@@ -158,7 +158,16 @@ function LookUpLW(ds, ::Type{FT}, ::Type{DA}) where {FT <: AbstractFloat, DA}
     kminor_start_lower = IA1D(Array(ds["kminor_start_lower"])) # not currently used
     kminor_start_upper = IA1D(Array(ds["kminor_start_upper"])) # not currently used
     planck_fraction = FTA4D(permutedims(Array(ds["plank_fraction"]), [2, 3, 4, 1]))
-    t_planck = FTA1D(Array(ds["temperature_Planck"]))
+    # Some reduced-resolution files (e.g. rrtmgp-gas-lw-g128.nc) store
+    # `temperature_Planck` as a 0-based index coordinate (0..195) instead of the
+    # physical temperatures (160..355 K). `totplnk` is on the standard 160 K-based
+    # grid in both cases, so reconstruct physical temperatures when the stored
+    # axis is clearly non-physical (avoids interp1d_equispaced clamping to 355 K).
+    t_planck_raw = Array(ds["temperature_Planck"])
+    if minimum(t_planck_raw) < 100  # not physical temperatures -> index coordinate
+        t_planck_raw = t_planck_raw .- minimum(t_planck_raw) .+ 160
+    end
+    t_planck = FTA1D(t_planck_raw)
 
     tot_planck = FTA2D(Array(ds["totplnk"]))
 


### PR DESCRIPTION
## Summary
Loading the reduced-resolution longwave k-distribution `rrtmgp-gas-lw-g128.nc`
(shipped in the `rrtmgp-data` v1.9 artifact) with `LookUpLW` produces grossly
wrong fluxes — global-mean OLR ≈ **895 W/m²** vs the correct **~246** from
`g256` on an identical atmosphere. This PR fixes the root cause; afterwards g128
matches g256 to ~0.3% at ~2× lower cost.

## Root cause
The full and reduced files store the Planck-table temperature axis differently:

| file | `temperature_Planck` |
| --- | --- |
| `g256` | physical temperatures **160 → 355 K** (Δ=1) |
| `g128` | a 0-based **index 0 → 195** (Δ=1) — not temperatures |

`totplnk` itself is byte-identical between the files. But the LW source uses
`interp1d_equispaced(T, t_planck, totplnk)` (`src/optics/Optics.jl`), which
assumes `t_planck` holds the physical, equispaced temperatures. With g128's
`[0..195]` axis a 288 K surface maps to index ≈ 288 and **clamps to the last
entry (355 K)** → emission over-counted by (355/288)⁴ ≈ **2.31×**, exactly the
observed 895/388 surface-flux inflation. Gas optics, `kmajor`,
`planck_fraction` (sums to 1), `major_gpt2bnd`, and minor-gas handling are all
correct — verified by probing `compute_gas_optics` per g-point in both the lower
and upper atmosphere.

## Fix
Reconstruct physical temperatures in `LookUpLW` when the stored axis is
non-physical. The SW reader does not read `temperature_Planck`, so no change is
needed there.

## Validation
T31-like 8-layer columns (~3000 columns), clear-sky `NoScatLWRTE`:

| metric | before | after |
| --- | --- | --- |
| g128 global-mean OLR | 895 W/m² | **245.3** (g256 = 246.0, **−0.3%**) |
| 2×CO₂ LW forcing | broken | 2.933 vs 2.914 W/m² (**+0.7%**) |
| `solve_lw!` cost | — | **~2× faster** than g256 |

i.e. the reduced k-distribution delivers its intended ~2× speedup for <1%
flux/forcing error once the temperature axis is read correctly.

## Notes
- `get_lookup_filename` currently only returns `g256`/`g224`, so the reduced
  files are untested and silently produce wrong fluxes; a regression test that
  loads `g128`/`g112` and checks fluxes vs `g256`/`g224` would catch this.
- Alternatively this could be addressed in `rrtmgp-data` by storing physical
  temperatures in `temperature_Planck` for the reduced files (as `g256` does).
  The heuristic here (`minimum(t_planck) < 100` ⇒ treat as index) is a
  reader-side guard; happy to adjust to whatever approach you prefer.
